### PR TITLE
Made lxc-portforward simpler, added logging to the helper script

### DIFF
--- a/lxc-portforward
+++ b/lxc-portforward
@@ -4,15 +4,5 @@
 
 # ARGS: container net up|down ...
 
-if [ "$2" = "net" -a "$3" = "up" ]
-then
-  at -M now 2>/dev/null <<UPSCRIPT
-sleep 30;
-/etc/lxc/lxc-portforward-helper up $1
-UPSCRIPT
-else
-  at -M now 2>/dev/null <<DOWNSCRIPT
-sleep 30;
-/etc/lxc/lxc-portforward-helper down $1
-DOWNSCRIPT
-fi
+[ "$2" = "net" ] && echo "/etc/lxc/lxc-portforward-helper $3 $1" | at -M now + 1 minutes 2>/dev/null
+

--- a/lxc-portforward-helper
+++ b/lxc-portforward-helper
@@ -12,12 +12,14 @@ then
 else
   ACTION="-D"
   IP="$(cat "/var/run/lxc-portforward/$CONTAINER")"
+  rm -f /var/run/lxc-portforward/$CONTAINER
 fi
 
 for line in $(grep "^$2:" /etc/lxc/lxc-portforward.conf)
 do
   FROM="$(echo $line | cut -f2 -d:)"
   TO="$(echo $line | cut -f3 -d:)"
-  iptables -t nat $ACTION PREROUTING -p tcp -i eth0 --dport "$FROM" -j DNAT --to-destination "$IP:$TO"
+  iptables -t nat $ACTION PREROUTING -p tcp -i eth0 --dport "$FROM" -j DNAT --to-destination "$IP:$TO"; retVal=$?
+  logger -t "`basename $0`" -p daemon.info "iptables -t nat $ACTION PREROUTING -p tcp -i eth0 --dport \"$FROM\" -j DNAT --to-destination \"$IP:$TO\": $retVal"
 done
 


### PR DESCRIPTION
- The `up` / `down` state can be handled by `lxc-portforward-helper` itself, so we can just 
   pass it on
- Added syslog logging via `logger`, so that we can check the result of `iptables` later on